### PR TITLE
Fix readme footnote link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Lamini: The LLM engine for rapidly customizing models 🦙
 [![License](https://img.shields.io/badge/License-CC%20By%204.0-green.svg)](/LICENSE.txt)
 [![Python 3.7+](https://img.shields.io/badge/python-3.7+-blue.svg)](https://www.python.org/downloads/release/python-370/)
@@ -77,7 +76,7 @@ Then, run this command:
 
 ## Expected Outputs & Autosaved Data 🦙
 When you run the program, you should start seeing output of a `Seed Question`, from the original small dataset in [`seed_tasks.jsonl`](./seed_tasks.jsonl), and a `Novel Question`, which is a generated question based on that `Seed Question`.[^1]
-[^1]: The `Seed Questions` in the Lamini seed dataset are instructions (combination of questions and commands), based on the [self-instruct dataset](https://github.com/yizhongw/self-instruct). The generated questions are similar in nature to those and therefore don't *have to* be questions. You can find the seed dataset at [`data/lamini_dataset.json`](./data/lamini_dataset.jsonl).
+[^1]: The `Seed Questions` in the Lamini seed dataset are instructions (combination of questions and commands), based on the [self-instruct dataset](https://github.com/yizhongw/self-instruct). The generated questions are similar in nature to those and therefore don't *have to* be questions. You can find the seed dataset at `data/lamini_dataset.jsonl`.
 ```
 ====== Seed Question =====
  question='Plan a weekly lunch menu for a school. Write down a main dish, a carbohydrate side dish, a vegetable side dish, and a dessert for each day.'


### PR DESCRIPTION
Unfortunately, it looks like relative markdown links are not supported in README footnotes. This PR removes the broken link, and also fixes a small typo in the filename (`json` vs `jsonl`). 