### PR TITLE
(fix): Ensure target directory is created in download_dataset + deprecated `datetime.utcnow()`

### DIFF
--- a/lamini/api/utils/reservations.py
+++ b/lamini/api/utils/reservations.py
@@ -146,7 +146,7 @@ class Reservations:
 
         if self.current_reservation is None:
             return
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.UTC)
         start_time = datetime.datetime.fromisoformat(
             self.current_reservation["start_time"]
         )
@@ -214,7 +214,7 @@ class Reservations:
         """
 
         try:
-            current_time = datetime.datetime.utcnow()
+            current_time = datetime.datetime.now(datetime.UTC)
             end_time = datetime.datetime.fromisoformat(wakeup_time)
             sleep_time = end_time - current_time
             if sleep_time.total_seconds() > 0:
@@ -263,7 +263,7 @@ class Reservations:
 
         if self.current_reservation is None:
             return
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.UTC)
         start_time = datetime.datetime.fromisoformat(
             self.current_reservation["start_time"]
         )

--- a/lamini/classify/lamini_classifier.py
+++ b/lamini/classify/lamini_classifier.py
@@ -120,7 +120,7 @@ class LaminiClassifier:
             output_dir_path = "./"
         else:
             # Ensure directories in output_dir_path exist
-            os.makedirs(os.path.dirname(output_dir_path), exist_ok=True)
+            os.makedirs(output_dir_path, exist_ok=True)
             
         # Set full path to the output file
         output_path = os.path.join(output_dir_path, filename)


### PR DESCRIPTION
### Description

The `os.makedirs` call was using `os.path.dirname(output_dir_path)`. This meant it was attempting to create the *parent* directory of the intended `output_dir_path`.

*   **Example:** If `output_dir_path` was specified as `"./my_datasets/specific_run"`, the old code would effectively do `os.makedirs("./my_datasets", exist_ok=True)`.
*   If `"./my_datasets"` existed but `"./my_datasets/specific_run"` did not, the subsequent `open(os.path.join(output_dir_path, filename), 'wb')` would fail because the `"specific_run"` subdirectory was never created.

**New Behavior & Fix:**
The `os.makedirs` call now targets `output_dir_path` directly: `os.makedirs(output_dir_path, exist_ok=True)`.

*   **Example:** If `output_dir_path` is `"./my_datasets/specific_run"`, this command will correctly create both `"./my_datasets"` (if it doesn't exist) and `"./my_datasets/specific_run"` (if it doesn't exist).
*   This ensures the full path specified by `output_dir_path` is available before attempting to save the downloaded file into it via `os.path.join(output_dir_path, filename)`.

This fix prevents `FileNotFoundError` when `output_dir_path` includes subdirectories that don't yet exist and aligns the directory creation with the path used for saving the file.

Also see https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221 for the minor datetime issue.